### PR TITLE
Remove moduleId from Component snippet

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -97,7 +97,6 @@
       "import { Component, OnInit } from '@angular/core';",
       "",
       "@Component({",
-      "\tmoduleId: module.id,",
       "\tselector: '${selector}',",
       "\ttemplateUrl: '${fileName}.component.html'",
       "})",


### PR DESCRIPTION
Remove moduleId from Component snippet as it's no longer recommended as of March 13 2017.

More info here: [https://angular.io/guide/change-log#all-mention-of-moduleid-removed-component-relative-paths-guide-deleted-2017-03-13](https://angular.io/guide/change-log#all-mention-of-moduleid-removed-component-relative-paths-guide-deleted-2017-03-13)