### PR TITLE
Added the public modifier to the snippets of InputProperty, InputGetSet and OutputEvent

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -270,7 +270,7 @@
   "Input": {
     "prefix": "ag-InputProperty",
     "body": [
-      "@Input() ${propertyName}: ${propertyType};"
+      "@Input() public ${propertyName}: ${propertyType};"
     ],
     "description": "Angular @Input property snippet (import Input from @angular/core to use)"
   },
@@ -279,11 +279,11 @@
     "prefix": "ag-InputGetSet",
     "body": [
       "private _${propertyName}: ${propertyType};",
-      "@Input() get ${propertyName}() {",
+      "@Input() public get ${propertyName}() {",
       "\treturn this._${propertyName};",
       "}",
       "",
-      "set ${propertyName}(val: ${propertyType}) { ",
+      "public set ${propertyName}(val: ${propertyType}) { ",
       "\tthis._${propertyName} = val;",
       "}"
     ],
@@ -293,7 +293,7 @@
   "Output": {
     "prefix": "ag-OutputEvent",
     "body": [
-      "@Output() ${eventName}: EventEmitter<${eventDataType}> = new EventEmitter<${eventDataType}>();"
+      "@Output() public ${eventName}: EventEmitter<${eventDataType}> = new EventEmitter<${eventDataType}>();"
     ],
     "description": "Angular @Output event snippet (import Output and EventEmitter from @angular/core to use)"
   }


### PR DESCRIPTION
Updated snippets for Input, InputGetSet and Output.

This snippets will be generated with the "public" modifier.

### InputGetSet
```js
private _propertyName: propertyType;
@Input() public get propertyName() {
    return this._propertyName;
}

public set propertyName(val: propertyType) { 
    this._propertyName = val;
}
```

### InputProperty
```js
@Input() propertyName: propertyType;
```


### OutputEvent
```js
@Output() eventName: EventEmitter<eventDataType> = new EventEmitter<eventDataType>();```